### PR TITLE
#13 : Use Content Switcher on Menu Pages

### DIFF
--- a/Common/UI/ContentSwitcher/content_switcher.gd
+++ b/Common/UI/ContentSwitcher/content_switcher.gd
@@ -2,15 +2,17 @@ extends Control
 
 signal Switched(scn: Node)
 
-@export var current_scene: Node
+@onready var current_scene = $Home
+#@export var current_scene: Node
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	pass # Replace with function body.
 
-func load_scene(scene: String, animation: int):
+func load_scene(scene: String, animation: int, new_scene: Control = null):
 	print("Switching to:", scene)
-	var new_scene = ResourceLoader.load(scene).instantiate()
+	if null == new_scene :
+		new_scene = ResourceLoader.load(scene).instantiate()
 
 	#Swap scenes
 	animate_swap(new_scene, animation)
@@ -21,6 +23,10 @@ func load_scene(scene: String, animation: int):
 	#Let any listeners know we switched a scene. Usually, they will get the scene and set data
 	emit_signal("Switched", current_scene)
 
+func load_scene_home(scene: String, animation: int = 0):
+	var new_scene = ResourceLoader.load(scene).instantiate()
+	new_scene.position.y = 163
+	load_scene(scene, animation, new_scene)
 
 func load_scene_with_props(scene: String, animation: int, keys, vals):
 	print("Switching to:", scene)

--- a/Common/UI/ContentSwitcher/content_switcher.gd
+++ b/Common/UI/ContentSwitcher/content_switcher.gd
@@ -2,8 +2,7 @@ extends Control
 
 signal Switched(scn: Node)
 
-@onready var current_scene = $Home
-#@export var current_scene: Node
+@export var current_scene: Node
 
 # Called when the node enters the scene tree for the first time.
 func _ready():

--- a/Menu/SubMenu/Unit/Display/view_units.gd
+++ b/Menu/SubMenu/Unit/Display/view_units.gd
@@ -29,7 +29,7 @@ func create_thumbnail(unit: Unit):
 
 func _on_unit_pressed(unit: Unit):
 	print(unit)
-	get_parent().load_scene("res://Menu/SubMenu/Unit/Display/unit_display.tscn")
+	get_parent().load_scene_home("res://Menu/SubMenu/Unit/Display/unit_display.tscn")
 
 func _on_back_pressed():
-	get_parent().load_scene("res://Menu/SubMenu/Unit/unit_menu.tscn")
+	get_parent().load_scene_home("res://Menu/SubMenu/Unit/unit_menu.tscn")

--- a/Menu/SubMenu/Unit/unit_menu.gd
+++ b/Menu/SubMenu/Unit/unit_menu.gd
@@ -15,7 +15,7 @@ func _on_button_pressed(button: int):
 	#Load the related submenu
 	match button:
 		1:
-			get_parent().load_scene("res://Menu/SubMenu/Unit/Display/view_units.tscn")
+			get_parent().load_scene_home("res://Menu/SubMenu/Unit/Display/view_units.tscn")
 
 func _on_back_pressed():
-	get_parent().load_scene("res://Menu/SubMenu/Home/home.tscn")
+	get_parent().load_scene_home("res://Menu/SubMenu/Home/home.tscn")

--- a/Menu/main_menu.gd
+++ b/Menu/main_menu.gd
@@ -7,5 +7,5 @@ func _ready():
 
 func _on_footer_btn_clicked(id:int):
 	match id:
-		1: $MenuContent.load_scene("res://Menu/SubMenu/Home/home.tscn", 1)
-		2: $MenuContent.load_scene("res://Menu/SubMenu/Unit/unit_menu.tscn", 1)
+		1: $content_switcher.load_scene_home("res://Menu/SubMenu/Home/home.tscn", 1)
+		2: $content_switcher.load_scene_home("res://Menu/SubMenu/Unit/unit_menu.tscn", 1)

--- a/Menu/main_menu.gd
+++ b/Menu/main_menu.gd
@@ -4,6 +4,8 @@ extends Control
 func _ready():
 	print("Menu Ready")
 	get_tree().root.get_node("Game").get_child(0).emit_signal("startPlaying", "res://Music/1-02 The Summoner.mp3")
+	# Load the home screen
+	$content_switcher.load_scene_home("res://Menu/SubMenu/Home/home.tscn")
 
 func _on_footer_btn_clicked(id:int):
 	match id:

--- a/Menu/main_menu.tscn
+++ b/Menu/main_menu.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=9 format=3 uid="uid://fchfdi1cto6s"]
+[gd_scene load_steps=8 format=3 uid="uid://fchfdi1cto6s"]
 
 [ext_resource type="Script" path="res://Menu/main_menu.gd" id="1_rk2ft"]
-[ext_resource type="PackedScene" uid="uid://pcg0jhi8nlpx" path="res://Menu/SubMenu/Home/home.tscn" id="5_2t0h2"]
 [ext_resource type="Script" path="res://Common/UI/ContentSwitcher/content_switcher.gd" id="7_0g887"]
 [ext_resource type="PackedScene" uid="uid://bfku18he8vhad" path="res://Menu/Header/header.tscn" id="14_e2vs6"]
 [ext_resource type="PackedScene" uid="uid://c5dlinvyudexr" path="res://Menu/Footer/footer.tscn" id="15_dceir"]
@@ -41,14 +40,6 @@ anchors_preset = 0
 offset_right = 40.0
 offset_bottom = 40.0
 script = ExtResource("7_0g887")
-
-[node name="Home" parent="content_switcher" instance=ExtResource("5_2t0h2")]
-z_index = -1
-layout_mode = 1
-offset_left = -4.0
-offset_top = 163.0
-offset_right = -4.0
-offset_bottom = 163.0
 
 [node name="MenuSlideAndFade" type="AnimationPlayer" parent="content_switcher"]
 libraries = {

--- a/Menu/main_menu.tscn
+++ b/Menu/main_menu.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" path="res://Menu/main_menu.gd" id="1_rk2ft"]
 [ext_resource type="PackedScene" uid="uid://pcg0jhi8nlpx" path="res://Menu/SubMenu/Home/home.tscn" id="5_2t0h2"]
-[ext_resource type="Script" path="res://Menu/MenuContent.gd" id="5_u6iju"]
+[ext_resource type="Script" path="res://Common/UI/ContentSwitcher/content_switcher.gd" id="7_0g887"]
 [ext_resource type="PackedScene" uid="uid://bfku18he8vhad" path="res://Menu/Header/header.tscn" id="14_e2vs6"]
 [ext_resource type="PackedScene" uid="uid://c5dlinvyudexr" path="res://Menu/Footer/footer.tscn" id="15_dceir"]
 [ext_resource type="Texture2D" uid="uid://ku4h8un7lqso" path="res://Menu/base.jpg" id="19_6bdlw"]
@@ -35,14 +35,14 @@ expand_mode = 1
 [node name="Footer" parent="." instance=ExtResource("15_dceir")]
 footer_message = "Welcome to Brave Frontier!"
 
-[node name="MenuContent" type="Control" parent="."]
+[node name="content_switcher" type="Control" parent="."]
 layout_mode = 3
 anchors_preset = 0
 offset_right = 40.0
 offset_bottom = 40.0
-script = ExtResource("5_u6iju")
+script = ExtResource("7_0g887")
 
-[node name="Home" parent="MenuContent" instance=ExtResource("5_2t0h2")]
+[node name="Home" parent="content_switcher" instance=ExtResource("5_2t0h2")]
 z_index = -1
 layout_mode = 1
 offset_left = -4.0
@@ -50,7 +50,7 @@ offset_top = 163.0
 offset_right = -4.0
 offset_bottom = 163.0
 
-[node name="MenuSlideAndFade" type="AnimationPlayer" parent="MenuContent"]
+[node name="MenuSlideAndFade" type="AnimationPlayer" parent="content_switcher"]
 libraries = {
 "": SubResource("AnimationLibrary_ry27w")
 }


### PR DESCRIPTION
See Issue-https://github.com/aMytho/brave-frontier-godot/issues/13 for more information

Explanation of the solution : 

At first, I tried to use strictly the content_switcher instead of the MenuSwitcher for the MenuPage. And so, the page displayed, after the first click in unit or home button, was more up than usual (like the button were under the header for unit)

After a bit of code-reading, I assumed the line `new_scene.position.y = 163` was helping the page to caliber itself.
So I created a new method **load_scene_home** that will set the line from before just before entering the real "load_scene" method

If you see a better solution, let me know !