### PR TITLE
Add live stats change by updating healthbar of enemy/friendly units

### DIFF
--- a/Battle/Field/Enemies.gd
+++ b/Battle/Field/Enemies.gd
@@ -1,5 +1,7 @@
 extends Control
 
+signal UpdateTarget(place_ID: int)
+
 # The current unit under attack. Will be used by parent nodes
 @export var current_target: int = -1
 
@@ -22,6 +24,7 @@ func _on_target_selected(id: int):
 		else:
 			# Set the current target
 			current_target = id
+			emit_signal("UpdateTarget", target.place_ID)
 
 # Get the target in the enemy team
 ### If no target, then we choose a random target

--- a/Battle/Field/field_unit.gd
+++ b/Battle/Field/field_unit.gd
@@ -2,6 +2,7 @@ extends Area2D
 
 signal AttackFinished(id: int)
 signal TargetSelected(id: int)
+
 # Flag to let parent scenes check if a unit is in this slot
 @export var is_unit = false
 # Corresponds to the unit placement in unit_display
@@ -76,7 +77,6 @@ func _on_animation_finished():
 func remove_target():
 	is_targeted = false
 	$Target.visible = false
-
 
 # This event is trigger when the user click on a unit.
 # If it's an enemy unit (!is_friendly), this will add a target on it, if the unit is not dead

--- a/Battle/UI/battle_potential_rewards.tscn
+++ b/Battle/UI/battle_potential_rewards.tscn
@@ -26,12 +26,14 @@ grow_vertical = 2
 texture = ExtResource("1_3cd8r")
 
 [node name="Zel" type="TextureRect" parent="."]
+layout_mode = 0
 offset_top = 37.0
 offset_right = 148.0
 offset_bottom = 69.0
 texture = SubResource("AtlasTexture_xhjrh")
 
 [node name="Label" type="Label" parent="Zel"]
+layout_mode = 0
 offset_left = 35.0
 offset_top = 4.0
 offset_right = 119.0
@@ -39,6 +41,7 @@ offset_bottom = 30.0
 text = "X00000000"
 
 [node name="Karma" type="TextureRect" parent="."]
+layout_mode = 0
 offset_left = 274.0
 offset_top = 38.0
 offset_right = 427.0
@@ -46,6 +49,7 @@ offset_bottom = 70.0
 texture = SubResource("AtlasTexture_ylejr")
 
 [node name="Label" type="Label" parent="Karma"]
+layout_mode = 0
 offset_left = 37.0
 offset_top = 5.0
 offset_right = 130.0
@@ -53,6 +57,7 @@ offset_bottom = 31.0
 text = "X00000000"
 
 [node name="Units" type="TextureRect" parent="."]
+layout_mode = 0
 offset_left = 456.0
 offset_top = 38.0
 offset_right = 555.0
@@ -60,6 +65,7 @@ offset_bottom = 70.0
 texture = SubResource("AtlasTexture_2kdm3")
 
 [node name="Label" type="Label" parent="Units"]
+layout_mode = 0
 offset_left = 33.0
 offset_top = 5.0
 offset_right = 73.0

--- a/Battle/UI/battle_ui.gd
+++ b/Battle/UI/battle_ui.gd
@@ -27,7 +27,8 @@ func setCharacter():
 func set_selected_enemy_health(enemy_unit: Resource):
 	selected_enemy = enemy_unit
 	var enemy_health_bar = $EnemyHealth/HPBar
-	$EnemyHealth/HP.set_text("HP : %s%" % int(float(selected_enemy.HP / selected_enemy.max_HP * 100)))
+	var prcent_hp = int(float(selected_enemy.HP) / selected_enemy.max_HP * 100)
+	$EnemyHealth/HP.set_text("HP : %s%s" % [prcent_hp if 0 <= prcent_hp else 0, "%"])
 	$EnemyHealth/Name.text = selected_enemy.name
 	enemy_health_bar.max_value = selected_enemy.max_HP
 	enemy_health_bar.value = selected_enemy.HP

--- a/Battle/UI/battle_ui.gd
+++ b/Battle/UI/battle_ui.gd
@@ -5,6 +5,8 @@ extends Control
 		units = new_units
 		setCharacter()
 
+@export var selected_enemy: Resource
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	print("Its ready")
@@ -21,6 +23,14 @@ func setCharacter():
 		else:
 			get_node(charPath).create_unit(unit.battle_thumbnail, unit.name, unit.element, unit.HP)
 		count = count + 1
+
+func set_selected_enemy_health(enemy_unit: Resource):
+	selected_enemy = enemy_unit
+	var enemy_health_bar = $EnemyHealth/HPBar
+	$EnemyHealth/HP.set_text("HP : %s%" % int(float(selected_enemy.HP / selected_enemy.max_HP * 100)))
+	$EnemyHealth/Name.text = selected_enemy.name
+	enemy_health_bar.max_value = selected_enemy.max_HP
+	enemy_health_bar.value = selected_enemy.HP
 
 func release_attack_lockout():
 	# allow each unit to attack again

--- a/Battle/UI/battle_ui.tscn
+++ b/Battle/UI/battle_ui.tscn
@@ -24,32 +24,32 @@ gradient = SubResource("Gradient_l8yft")
 atlas = ExtResource("1_0qsqw")
 region = Rect2(1, 526, 597, 15)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_uai5w"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_7qg4o"]
 resource_local_to_scene = true
 atlas = ExtResource("1_0qsqw")
 region = Rect2(2, 2, 320, 117)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_fxber"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_cg3cc"]
 resource_local_to_scene = true
 atlas = ExtResource("1_0qsqw")
 region = Rect2(2, 2, 320, 117)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_jttbh"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_klifo"]
 resource_local_to_scene = true
 atlas = ExtResource("1_0qsqw")
 region = Rect2(2, 2, 320, 117)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_vd0lp"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_jpm3j"]
 resource_local_to_scene = true
 atlas = ExtResource("1_0qsqw")
 region = Rect2(2, 2, 320, 117)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_ep8lf"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_yndsq"]
 resource_local_to_scene = true
 atlas = ExtResource("1_0qsqw")
 region = Rect2(2, 2, 320, 117)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_mbn7i"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_d2qk3"]
 resource_local_to_scene = true
 atlas = ExtResource("1_0qsqw")
 region = Rect2(2, 2, 320, 117)
@@ -130,7 +130,7 @@ offset_left = 531.0
 offset_top = 87.0
 offset_right = 594.0
 offset_bottom = 113.0
-text = "HP: 48%"
+text = "HP: 49%"
 
 [node name="Name" type="Label" parent="EnemyHealth"]
 layout_mode = 0
@@ -159,7 +159,7 @@ offset_left = 1.0
 offset_top = 115.0
 offset_right = 321.0
 offset_bottom = 232.0
-texture = SubResource("AtlasTexture_uai5w")
+texture = SubResource("AtlasTexture_7qg4o")
 place_ID = 1
 
 [node name="Unit2" parent="." instance=ExtResource("2_nec6n")]
@@ -168,7 +168,7 @@ offset_left = 1.0
 offset_top = 229.0
 offset_right = 321.0
 offset_bottom = 346.0
-texture = SubResource("AtlasTexture_fxber")
+texture = SubResource("AtlasTexture_cg3cc")
 place_ID = 2
 
 [node name="Unit3" parent="." instance=ExtResource("2_nec6n")]
@@ -177,7 +177,7 @@ offset_left = 1.0
 offset_top = 346.0
 offset_right = 321.0
 offset_bottom = 463.0
-texture = SubResource("AtlasTexture_jttbh")
+texture = SubResource("AtlasTexture_klifo")
 place_ID = 3
 
 [node name="Unit4" parent="." instance=ExtResource("2_nec6n")]
@@ -186,7 +186,7 @@ offset_left = 321.0
 offset_top = 115.0
 offset_right = 641.0
 offset_bottom = 232.0
-texture = SubResource("AtlasTexture_vd0lp")
+texture = SubResource("AtlasTexture_jpm3j")
 place_ID = 4
 
 [node name="Unit5" parent="." instance=ExtResource("2_nec6n")]
@@ -195,7 +195,7 @@ offset_left = 321.0
 offset_top = 229.0
 offset_right = 641.0
 offset_bottom = 346.0
-texture = SubResource("AtlasTexture_ep8lf")
+texture = SubResource("AtlasTexture_yndsq")
 place_ID = 5
 
 [node name="Unit6" parent="." instance=ExtResource("2_nec6n")]
@@ -204,7 +204,7 @@ offset_left = 321.0
 offset_top = 346.0
 offset_right = 641.0
 offset_bottom = 463.0
-texture = SubResource("AtlasTexture_mbn7i")
+texture = SubResource("AtlasTexture_d2qk3")
 place_ID = 6
 
 [node name="Overdrive" type="TextureRect" parent="."]

--- a/Battle/UI/battle_ui.tscn
+++ b/Battle/UI/battle_ui.tscn
@@ -24,32 +24,32 @@ gradient = SubResource("Gradient_l8yft")
 atlas = ExtResource("1_0qsqw")
 region = Rect2(1, 526, 597, 15)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_uxj37"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_uai5w"]
 resource_local_to_scene = true
 atlas = ExtResource("1_0qsqw")
 region = Rect2(2, 2, 320, 117)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_22b16"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_fxber"]
 resource_local_to_scene = true
 atlas = ExtResource("1_0qsqw")
 region = Rect2(2, 2, 320, 117)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_p6xbo"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_jttbh"]
 resource_local_to_scene = true
 atlas = ExtResource("1_0qsqw")
 region = Rect2(2, 2, 320, 117)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_u7s2r"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_vd0lp"]
 resource_local_to_scene = true
 atlas = ExtResource("1_0qsqw")
 region = Rect2(2, 2, 320, 117)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_iiok1"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_ep8lf"]
 resource_local_to_scene = true
 atlas = ExtResource("1_0qsqw")
 region = Rect2(2, 2, 320, 117)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_dwhul"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_mbn7i"]
 resource_local_to_scene = true
 atlas = ExtResource("1_0qsqw")
 region = Rect2(2, 2, 320, 117)
@@ -113,14 +113,6 @@ offset_right = 40.0
 offset_bottom = 40.0
 texture = SubResource("AtlasTexture_dwo8k")
 
-[node name="HP" type="Label" parent="EnemyHealth"]
-layout_mode = 0
-offset_left = 558.0
-offset_top = 89.0
-offset_right = 621.0
-offset_bottom = 115.0
-text = "HP: 48%"
-
 [node name="HPBar" type="TextureProgressBar" parent="EnemyHealth"]
 layout_mode = 0
 offset_left = 23.0
@@ -131,6 +123,14 @@ value = 50.0
 allow_greater = true
 texture_under = SubResource("GradientTexture1D_xjcv3")
 texture_progress = SubResource("AtlasTexture_h1fir")
+
+[node name="HP" type="Label" parent="EnemyHealth"]
+layout_mode = 0
+offset_left = 531.0
+offset_top = 87.0
+offset_right = 594.0
+offset_bottom = 113.0
+text = "HP: 48%"
 
 [node name="Name" type="Label" parent="EnemyHealth"]
 layout_mode = 0
@@ -159,7 +159,7 @@ offset_left = 1.0
 offset_top = 115.0
 offset_right = 321.0
 offset_bottom = 232.0
-texture = SubResource("AtlasTexture_uxj37")
+texture = SubResource("AtlasTexture_uai5w")
 place_ID = 1
 
 [node name="Unit2" parent="." instance=ExtResource("2_nec6n")]
@@ -168,7 +168,7 @@ offset_left = 1.0
 offset_top = 229.0
 offset_right = 321.0
 offset_bottom = 346.0
-texture = SubResource("AtlasTexture_22b16")
+texture = SubResource("AtlasTexture_fxber")
 place_ID = 2
 
 [node name="Unit3" parent="." instance=ExtResource("2_nec6n")]
@@ -177,7 +177,7 @@ offset_left = 1.0
 offset_top = 346.0
 offset_right = 321.0
 offset_bottom = 463.0
-texture = SubResource("AtlasTexture_p6xbo")
+texture = SubResource("AtlasTexture_jttbh")
 place_ID = 3
 
 [node name="Unit4" parent="." instance=ExtResource("2_nec6n")]
@@ -186,7 +186,7 @@ offset_left = 321.0
 offset_top = 115.0
 offset_right = 641.0
 offset_bottom = 232.0
-texture = SubResource("AtlasTexture_u7s2r")
+texture = SubResource("AtlasTexture_vd0lp")
 place_ID = 4
 
 [node name="Unit5" parent="." instance=ExtResource("2_nec6n")]
@@ -195,7 +195,7 @@ offset_left = 321.0
 offset_top = 229.0
 offset_right = 641.0
 offset_bottom = 346.0
-texture = SubResource("AtlasTexture_iiok1")
+texture = SubResource("AtlasTexture_ep8lf")
 place_ID = 5
 
 [node name="Unit6" parent="." instance=ExtResource("2_nec6n")]
@@ -204,7 +204,7 @@ offset_left = 321.0
 offset_top = 346.0
 offset_right = 641.0
 offset_bottom = 463.0
-texture = SubResource("AtlasTexture_dwhul")
+texture = SubResource("AtlasTexture_mbn7i")
 place_ID = 6
 
 [node name="Overdrive" type="TextureRect" parent="."]

--- a/Battle/UI/unit.gd
+++ b/Battle/UI/unit.gd
@@ -1,5 +1,9 @@
 extends TextureRect
 
+const green_bar = Rect2(2, 545, 176, 10)
+const yellow_bar = Rect2(2, 560, 176, 11)
+const red_bar = Rect2(2, 575, 176, 12)
+
 var ElementLocations = [
 	Rect2(37, 919, 27, 27), # Fire
 	Rect2(64, 919, 26, 26), # Water
@@ -40,30 +44,13 @@ func create_unit(icon, uName, element, HP):
 	unit_HP = HP
 	live_unit_HP = HP
 	has_unit = true
-	set_default_health_bar_data()
-	set_live_health_bar_data()
-	$HPContainer/HPNotFull.visible = false
-	$HPContainer/HPDanger.visible = false
-	
-	print($HPContainer/Bar.value)
-	print($HPContainer/Bar.value)
-	
+	$HPContainer/Bar.max_value = unit_HP
+	$HPContainer/Bar.value = live_unit_HP	
 	#Get their actual values
 	get_node("Element").texture.region = setElement(unit_element)
 	get_node("Name").text = unit_name
 	update_HP_container(live_unit_HP)
 	get_node("PlayerFrame").texture = icon
-
-
-func set_default_health_bar_data():
-	$HPContainer/HPNotFull.max_value = unit_HP
-	$HPContainer/HPDanger.max_value = unit_HP
-	$HPContainer/Bar.max_value = unit_HP
-	
-func set_live_health_bar_data():
-	$HPContainer/HPNotFull.value = live_unit_HP
-	$HPContainer/HPDanger.value = live_unit_HP
-	$HPContainer/Bar.value = live_unit_HP
 
 func reset_placeholder():
 	# runs when a unit isn't in a slot. Reset all values
@@ -77,30 +64,24 @@ func reset_placeholder():
 	get_node("Element").texture.region = Rect2(0,0,0,0)
 	$Name.visible = false
 	$HPContainer.visible = false
-	$HPContainer/HPNotFull.visible = false
-	$HPContainer/HPDanger.visible = false
 	$BBAnimation.visible = false
 	$BBContainer.visible = false
 	$HPContainer.visible = false
 	$PlayerFrame.visible = false
 
+# When called, update the live HP of a unit with the new HP send in parameters
 func update_HP_container(new_HP: int):
 	print("HP container updated")
+	var HP_bar = $HPContainer/Bar
 	live_unit_HP = new_HP if new_HP > 0 else 0
+	HP_bar.value = live_unit_HP
 	get_node("HPContainer/Label").text = str(live_unit_HP, "/", unit_HP)
-	set_live_health_bar_data()
 	if (unit_HP == live_unit_HP):
-		$HPContainer/Bar.visible = true
-		$HPContainer/HPNotFull.visible = false
-		$HPContainer/HPDanger.visible = false
-	elif int(unit_HP/3) <= live_unit_HP:
-		$HPContainer/Bar.visible = false
-		$HPContainer/HPNotFull.visible = true
-		$HPContainer/HPDanger.visible = false
+		HP_bar.texture_progress.region = green_bar
+	elif int(unit_HP/3.0) <= live_unit_HP:
+		HP_bar.texture_progress.region = yellow_bar
 	else:
-		$HPContainer/Bar.visible = false
-		$HPContainer/HPNotFull.visible = false
-		$HPContainer/HPDanger.visible = true
+		HP_bar.texture_progress.region = red_bar
 
 func setElement(element):
 	match element:

--- a/Battle/UI/unit.gd
+++ b/Battle/UI/unit.gd
@@ -23,6 +23,7 @@ signal Die
 @export var unit_name:String = ""
 @export var unit_element:String = "Fire"
 @export var unit_HP: int = 500
+@export var live_unit_HP: int = 500
 @export var is_dead: bool = false
 
 @export_category("Unit Dev Info")
@@ -37,12 +38,32 @@ func create_unit(icon, uName, element, HP):
 	unit_name = uName
 	unit_element = element
 	unit_HP = HP
+	live_unit_HP = HP
 	has_unit = true
+	set_default_health_bar_data()
+	set_live_health_bar_data()
+	$HPContainer/HPNotFull.visible = false
+	$HPContainer/HPDanger.visible = false
+	
+	print($HPContainer/Bar.value)
+	print($HPContainer/Bar.value)
+	
 	#Get their actual values
 	get_node("Element").texture.region = setElement(unit_element)
 	get_node("Name").text = unit_name
-	get_node("HPContainer/Label").text = str(unit_HP, "/", unit_HP)
+	get_node("HPContainer/Label").text = str(live_unit_HP, "/", unit_HP)
 	get_node("PlayerFrame").texture = icon
+
+
+func set_default_health_bar_data():
+	$HPContainer/HPNotFull.max_value = unit_HP
+	$HPContainer/HPDanger.max_value = unit_HP
+	$HPContainer/Bar.max_value = unit_HP
+	
+func set_live_health_bar_data():
+	$HPContainer/HPNotFull.value = live_unit_HP
+	$HPContainer/HPDanger.value = live_unit_HP
+	$HPContainer/Bar.value = live_unit_HP
 
 func reset_placeholder():
 	# runs when a unit isn't in a slot. Reset all values
@@ -56,10 +77,33 @@ func reset_placeholder():
 	get_node("Element").texture.region = Rect2(0,0,0,0)
 	$Name.visible = false
 	$HPContainer.visible = false
+	$HPContainer/HPNotFull.visible = false
+	$HPContainer/HPDanger.visible = false
 	$BBAnimation.visible = false
 	$BBContainer.visible = false
 	$HPContainer.visible = false
 	$PlayerFrame.visible = false
+
+func update_HP_container(new_HP: int):
+	print("HP container updated")
+	live_unit_HP = new_HP if new_HP > 0 else 0
+	get_node("HPContainer/Label").text = str(live_unit_HP, "/", unit_HP)
+	set_live_health_bar_data()
+	if (unit_HP == live_unit_HP):
+		print("full HP")
+		$HPContainer/Bar.visible = true
+		$HPContainer/HPNotFull.visible = false
+		$HPContainer/HPDanger.visible = false
+	elif int(unit_HP/3) <= live_unit_HP:
+		$HPContainer/Bar.visible = false
+		$HPContainer/HPNotFull.visible = true
+		$HPContainer/HPDanger.visible = false
+		print("not full but no danger")
+	else:
+		$HPContainer/Bar.visible = false
+		$HPContainer/HPNotFull.visible = false
+		$HPContainer/HPDanger.visible = true
+		print("DANGER")
 
 func setElement(element):
 	match element:

--- a/Battle/UI/unit.gd
+++ b/Battle/UI/unit.gd
@@ -51,7 +51,7 @@ func create_unit(icon, uName, element, HP):
 	#Get their actual values
 	get_node("Element").texture.region = setElement(unit_element)
 	get_node("Name").text = unit_name
-	get_node("HPContainer/Label").text = str(live_unit_HP, "/", unit_HP)
+	update_HP_container(live_unit_HP)
 	get_node("PlayerFrame").texture = icon
 
 
@@ -90,7 +90,6 @@ func update_HP_container(new_HP: int):
 	get_node("HPContainer/Label").text = str(live_unit_HP, "/", unit_HP)
 	set_live_health_bar_data()
 	if (unit_HP == live_unit_HP):
-		print("full HP")
 		$HPContainer/Bar.visible = true
 		$HPContainer/HPNotFull.visible = false
 		$HPContainer/HPDanger.visible = false
@@ -98,12 +97,10 @@ func update_HP_container(new_HP: int):
 		$HPContainer/Bar.visible = false
 		$HPContainer/HPNotFull.visible = true
 		$HPContainer/HPDanger.visible = false
-		print("not full but no danger")
 	else:
 		$HPContainer/Bar.visible = false
 		$HPContainer/HPNotFull.visible = false
 		$HPContainer/HPDanger.visible = true
-		print("DANGER")
 
 func setElement(element):
 	match element:

--- a/Battle/UI/unit.tscn
+++ b/Battle/UI/unit.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=18 format=3 uid="uid://bowmdjvwjl874"]
+[gd_scene load_steps=16 format=3 uid="uid://bowmdjvwjl874"]
 
 [ext_resource type="Texture2D" uid="uid://bkyewhpihrr81" path="res://Battle/UI/battle_ui.png" id="1_lidtk"]
 [ext_resource type="Script" path="res://Battle/UI/unit.gd" id="2_fo5lh"]
@@ -26,14 +26,6 @@ region = Rect2(439, 50, 185, 27)
 resource_local_to_scene = true
 atlas = ExtResource("1_lidtk")
 region = Rect2(2.08466, 545.292, 175.848, 10.4462)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_rukc4"]
-atlas = ExtResource("1_lidtk")
-region = Rect2(1.90301, 560.008, 176.082, 11.0793)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_5qcah"]
-atlas = ExtResource("1_lidtk")
-region = Rect2(1.92367, 574.926, 175.884, 12.108)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_cln5v"]
 atlas = ExtResource("1_lidtk")
@@ -144,23 +136,6 @@ offset_top = -19.0
 offset_right = 101.0
 offset_bottom = 7.0
 text = "500 / 500"
-
-[node name="HPNotFull" type="TextureProgressBar" parent="HPContainer"]
-layout_mode = 0
-offset_left = 5.0
-offset_top = 13.0
-offset_right = 181.0
-offset_bottom = 24.0
-value = 99.0
-texture_progress = SubResource("AtlasTexture_rukc4")
-
-[node name="HPDanger" type="TextureProgressBar" parent="HPContainer"]
-layout_mode = 0
-offset_left = 5.0
-offset_top = 13.0
-offset_right = 181.0
-offset_bottom = 24.0
-texture_progress = SubResource("AtlasTexture_5qcah")
 
 [node name="BBContainer" type="TextureRect" parent="."]
 layout_mode = 0

--- a/Battle/UI/unit.tscn
+++ b/Battle/UI/unit.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=3 uid="uid://bowmdjvwjl874"]
+[gd_scene load_steps=18 format=3 uid="uid://bowmdjvwjl874"]
 
 [ext_resource type="Texture2D" uid="uid://bkyewhpihrr81" path="res://Battle/UI/battle_ui.png" id="1_lidtk"]
 [ext_resource type="Script" path="res://Battle/UI/unit.gd" id="2_fo5lh"]
@@ -23,8 +23,17 @@ atlas = ExtResource("1_lidtk")
 region = Rect2(439, 50, 185, 27)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_pjqh6"]
+resource_local_to_scene = true
 atlas = ExtResource("1_lidtk")
-region = Rect2(2, 545, 176, 11)
+region = Rect2(2.08466, 545.292, 175.848, 10.4462)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_rukc4"]
+atlas = ExtResource("1_lidtk")
+region = Rect2(1.90301, 560.008, 176.082, 11.0793)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_5qcah"]
+atlas = ExtResource("1_lidtk")
+region = Rect2(1.92367, 574.926, 175.884, 12.108)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_cln5v"]
 atlas = ExtResource("1_lidtk")
@@ -136,6 +145,23 @@ offset_right = 101.0
 offset_bottom = 7.0
 text = "500 / 500"
 
+[node name="HPNotFull" type="TextureProgressBar" parent="HPContainer"]
+layout_mode = 0
+offset_left = 5.0
+offset_top = 13.0
+offset_right = 181.0
+offset_bottom = 24.0
+value = 99.0
+texture_progress = SubResource("AtlasTexture_rukc4")
+
+[node name="HPDanger" type="TextureProgressBar" parent="HPContainer"]
+layout_mode = 0
+offset_left = 5.0
+offset_top = 13.0
+offset_right = 181.0
+offset_bottom = 24.0
+texture_progress = SubResource("AtlasTexture_5qcah")
+
 [node name="BBContainer" type="TextureRect" parent="."]
 layout_mode = 0
 offset_left = 122.0
@@ -163,9 +189,9 @@ texture = SubResource("AtlasTexture_cd8qs")
 z_index = -2
 layout_mode = 0
 offset_left = -29.0
-offset_top = 4.0
+offset_top = 7.0
 offset_right = 278.0
-offset_bottom = 102.0
+offset_bottom = 105.0
 texture = SubResource("AtlasTexture_tn3ip")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="BBAnimation"]

--- a/Battle/stats_checking.gd
+++ b/Battle/stats_checking.gd
@@ -8,9 +8,7 @@ signal FriendlyUnitHasTakenDamage(place_ID: int)
 # But in the future, we could use DEF and buff from unit
 func unit_taking_damage(atk_unit: Resource, def_unit: Resource, friend_is_hurt: bool = false):
 	def_unit.HP = def_unit.HP - atk_unit.ATK
-	print(atk_unit)
 	if friend_is_hurt:
-		print("friend is hurt")
 		emit_signal("FriendlyUnitHasTakenDamage", def_unit)
 
 # Function call at the end of each turn
@@ -28,8 +26,6 @@ func are_units_dead(units: Array[Unit], isAllyUnits: bool = false):
 		if 0 >= unit.HP:
 			unit.is_dead = true
 			emit_signal("UnitHasDied", unitCount, isAllyUnits)
-			print("The unit is dead")
 		else:
 			unitLeft = unitLeft + 1
-			print("The unit is NOT dead")
 	return unitLeft

--- a/Battle/stats_checking.gd
+++ b/Battle/stats_checking.gd
@@ -1,12 +1,17 @@
 extends Node
 
 signal UnitHasDied(place_ID: int)
+signal FriendlyUnitHasTakenDamage(place_ID: int)
 
 # Make the defUnit lost HP
 # Right now, it only use the ATK stat of the atkUnit to reduce their HP
 # But in the future, we could use DEF and buff from unit
-func unit_taking_damage(atkUnit: Resource, defUnit: Resource):
-	defUnit.HP = defUnit.HP - atkUnit.ATK
+func unit_taking_damage(atk_unit: Resource, def_unit: Resource, friend_is_hurt: bool = false):
+	def_unit.HP = def_unit.HP - atk_unit.ATK
+	print(atk_unit)
+	if friend_is_hurt:
+		print("friend is hurt")
+		emit_signal("FriendlyUnitHasTakenDamage", def_unit)
 
 # Function call at the end of each turn
 # It check if a every unit of a team (units) still have enought HP

--- a/Units/unit_base.gd
+++ b/Units/unit_base.gd
@@ -18,6 +18,7 @@ var id: int = 0
 @export var is_dead:bool = false
 
 @export var HP: int = 0
+@export var max_HP: int = 0
 @export var ATK: int = 0
 @export var DEF: int = 0
 @export var REC: int = 0


### PR DESCRIPTION
Refers to Issue https://github.com/aMytho/brave-frontier-godot/issues/26

What does this PR do : 
- Update the visual life of each friendly units when they are attacked
- Update the health bar of the last selected monster when it's attacked
- - To understand this feature, in the original game, we could target a precise unit and the stats of this unit where displayed. but when you untarget, the stats stay. That is what this feature do
- The friendly unit health bar change color depending on it's status
- - When 100% HP : green
- - When HP > 1/3% HP : yellow
- - >When HP < 1/3% HP : red
- from 6d421126f20feeaf99ed15ec00d0df3c4115ee31 onward : Show the % of HP of the enemy unit who have the focus

Here is a gif of the actual work : https://drive.google.com/file/d/1IkbcYVSnO3pGlgxo8TbgUKw8uJXBMJlN/view?usp=sharing