### PR TITLE
Update death verification + multiple hit feature (first step)

### DIFF
--- a/Battle/Field/field_unit.gd
+++ b/Battle/Field/field_unit.gd
@@ -46,7 +46,7 @@ func set_properties(unit: Unit, flip: bool, new_idle_equipment, new_attack_equip
 	# A unit is here!
 	is_unit = true
 	is_dead = false
-	var frame = unit.sprite_sheet
+	var frames = unit.sprite_sheet
 	
 	targeted_place_ID = 0
 	time_being_targeted = 0

--- a/Battle/Field/field_unit.gd
+++ b/Battle/Field/field_unit.gd
@@ -2,6 +2,7 @@ extends Area2D
 
 signal AttackFinished(id: int)
 signal TargetSelected(id: int)
+signal DamagingEnemy(actual_unit: int, targeted_unit: int)
 
 # Flag to let parent scenes check if a unit is in this slot
 @export var is_unit = false
@@ -13,6 +14,12 @@ signal TargetSelected(id: int)
 @export var is_friendly: bool = true
 #Let the game know if the unit is dead or not
 @export var is_dead: bool = false
+# Remember the place ID of the unit being targeted by it's attack
+@export var targeted_place_ID:int = 0
+# Remember the number of unit currently attacking this unit
+@export var time_being_targeted:int = 0
+
+@export var hit_array:Array[int]
 # The sprite for the unit
 @onready var sprite = $Sprite
 # Store the equipment for the unit
@@ -31,13 +38,18 @@ func _ready():
 	# Always find a way back home...
 	initial_position = position
 
-func set_properties(frames, flip: bool, new_idle_equipment, new_attack_equipment, new_travel_equipment):
+
+func set_properties(unit: Unit, flip: bool, new_idle_equipment, new_attack_equipment, new_travel_equipment):
 	# Show the correct unit
-	sprite.sprite_frames = frames
-	
+	sprite.sprite_frames = unit.sprite_sheet
+	hit_array = unit.number_of_hit
 	# A unit is here!
 	is_unit = true
 	is_dead = false
+	var frame = unit.sprite_sheet
+	
+	targeted_place_ID = 0
+	time_being_targeted = 0
 	
 	# Face the correct direction
 	if flip:
@@ -117,7 +129,6 @@ func _on_move_finished(play_atk_animation: bool):
 	# Plays an attack animation or returns home
 	if play_atk_animation:
 		sprite.play("Attack")
-		
 		var counter = 0
 		for equipment in attack_equipment:
 			$Sprite/AtkEquipmentContainer.get_child(counter).play(equipment.name)
@@ -130,6 +141,8 @@ func _on_move_finished(play_atk_animation: bool):
 		for equipment in travel_equipment:
 			$Sprite/TravelEquipmentContainer.get_child(counter).play("Wait")
 			counter = counter + 1
+		for hit in hit_array:
+			emit_signal("DamagingEnemy", place_ID, targeted_place_ID, hit)
 	else:
 		var tween = create_tween()
 		tween.tween_property(self, "position", initial_position, 1.0 * speed)
@@ -153,7 +166,7 @@ func _on_unit_animation_finished(anim_name):
 		_on_move_finished(false)
 
 
-# This method remove the target of the unit (because the user select it again or the unit has died)
+# This method remove the target of the unit (because the user select it again or the unit has died) 
 func remove_target():
 	is_targeted = false
 	$Target.visible = false

--- a/Battle/battle.gd
+++ b/Battle/battle.gd
@@ -38,7 +38,7 @@ func _ready():
 	$BattleUI.units = units
 	
 	battleUIUnitAttackConnect()
-	$stats_checking.UnitHasDied.connect(_when_unit_has_died)
+	set_damaging_signal()
 	$stats_checking.FriendlyUnitHasTakenDamage.connect(_unit_UI_update)
 	$Enemies.UpdateTarget.connect(_update_enemy_s_data)
 	
@@ -51,10 +51,16 @@ func _ready():
 			units[i].max_HP = units[i].HP
 			var child_node = freindly_units.get_child(i)
 			child_node.set_properties(
-				units[i].sprite_sheet, false, units[i].char_equipment,
+				units[i], false, units[i].char_equipment,
 				units[i].atk_equipment, units[i].travel_equipment)
 	# Setup the environment
 	load_next_stage(0)
+
+func set_damaging_signal():
+	for enemy in $Enemies.get_children():
+		enemy.DamagingEnemy.connect(_damaging_targeted_unit)
+	for friend in $Friendlies.get_children():
+		friend.DamagingEnemy.connect(_damaging_targeted_unit)
 
 func battleUIUnitAttackConnect():
 	$BattleUI/Unit1.Attack.connect(_unit_attack)
@@ -64,6 +70,33 @@ func battleUIUnitAttackConnect():
 	$BattleUI/Unit5.Attack.connect(_unit_attack)
 	$BattleUI/Unit6.Attack.connect(_unit_attack)
 
+func _damaging_targeted_unit(damaging_unit_id: int, hurt_unit_id: int, quantity_of_damage: int):
+	var monsters_list = zone.Stage[current_stage - 1].monsters	
+	var damaging_field_unit
+	var damaging_unit
+	var hurt_field_unit
+	var hurt_unit
+	var friend_is_hurt
+	var percent_of_damage = quantity_of_damage / 100.0
+	
+	if player_turn:
+		damaging_field_unit = get_node(str("./Friendlies/Unit", damaging_unit_id))
+		damaging_unit = units[damaging_unit_id - 1]
+		hurt_field_unit = get_node(str("./Enemies/Unit", hurt_unit_id))
+		hurt_unit = monsters_list[hurt_unit_id - 1]
+		friend_is_hurt = false
+	else:
+		damaging_field_unit = get_node(str("./Enemies/Unit", damaging_unit_id))
+		damaging_unit = monsters_list[damaging_unit_id - 1]
+		hurt_field_unit = get_node(str("./Friendlies/Unit", hurt_unit_id))
+		hurt_unit = units[hurt_unit_id - 1]
+		print(hurt_field_unit)
+		friend_is_hurt = true
+	
+	$stats_checking.unit_taking_damage(damaging_unit.ATK * percent_of_damage, hurt_unit, friend_is_hurt)
+	if hurt_unit == $BattleUI.selected_enemy:
+		$BattleUI.set_selected_enemy_health(hurt_unit)
+
 # Method trigger when the BattleUI of a friendly unit has been clicked (see res://Battle/UI/unit.gd for more
 # In this function, if a unit is not dead and exist, we would call the function attack to active the animation
 # We also call a function to lower the HP of the attacked unit
@@ -71,20 +104,33 @@ func _unit_attack(unit_place: int):
 	# Play attack animation, listen for anim end
 	if null != units[unit_place-1] and !units[unit_place-1].is_dead:
 		var target = $Enemies.get_target()
+		var attaking_unit = get_node(str("./Friendlies/Unit", unit_place))
 		var target_monster = zone.Stage[current_stage-1].monsters[target.place_ID - 1]
-		get_node(str("./Friendlies/Unit", unit_place)).attack(target.position)
-		$stats_checking.unit_taking_damage(units[unit_place-1], zone.Stage[current_stage-1].monsters[target.place_ID - 1])
-		if target_monster == $BattleUI.selected_enemy:
-			$BattleUI.set_selected_enemy_health(target_monster)
-		get_node(str("./Friendlies/Unit", unit_place)).connect("AttackFinished", _unit_attack_finished)
+		target.time_being_targeted += 1
+		attaking_unit.targeted_place_ID = target.place_ID
+		attaking_unit.attack(target.position)
+		attaking_unit.connect("AttackFinished", _unit_attack_finished)
 
 # Each time a unit end their turn, we increment the number of units attacked
 func _unit_attack_finished(unit_place: int):
 	# Disconnect the signal
-	get_node(str("./Friendlies/Unit", unit_place)).disconnect("AttackFinished", _unit_attack_finished)
+	var friend_unit = get_node(str("./Friendlies/Unit", unit_place))
+	friend_unit.disconnect("AttackFinished", _unit_attack_finished)
 	# Check if the turn is over
 	units_attacked = units_attacked + 1
+	check_if_unit_is_dead(friend_unit, true)
 	check_if_player_turn_complete()
+
+func check_if_unit_is_dead(unit, is_friendly_attacking: bool = false):
+	print("Is the unit dead ?")
+	var hurted_unit_place_ID = unit.targeted_place_ID
+	var hurted_field_unit = get_node(str("./Enemies/Unit", hurted_unit_place_ID)) if is_friendly_attacking else get_node(str("./Friendlies/Unit", hurted_unit_place_ID))
+	var hurted_unit = zone.Stage[current_stage - 1].monsters[hurted_unit_place_ID - 1] if is_friendly_attacking else units[hurted_unit_place_ID - 1]
+	
+	unit.targeted_place_ID = 0
+	hurted_field_unit.time_being_targeted -= 1
+	if 0 >= hurted_unit.HP and 0 >= hurted_field_unit.time_being_targeted:
+		when_unit_has_died(hurted_unit_place_ID, !is_friendly_attacking)
 
 func _update_enemy_s_data(place_ID: int):
 	$BattleUI.set_selected_enemy_health(zone.Stage[current_stage-1].monsters[place_ID-1])
@@ -95,15 +141,15 @@ func _update_enemy_s_data(place_ID: int):
 ### if not, enemy turn start
 func check_if_player_turn_complete():
 	# If the player has had all units attack, end turn
-	if units_attacked == total_allies:
+	var enemy_unit_left = $stats_checking.are_all_units_dead(zone.Stage[current_stage-1].monsters, $Enemies.get_children())
+	if units_attacked == total_allies or 0 == enemy_unit_left:
 		print("Ready for enemy turn")
 		player_turn = false
 		enemy_turn = true
 		units_attacked = 0
-		total_enemies = $stats_checking.are_units_dead(zone.Stage[current_stage-1].monsters)
 		# Dev only. This allows us to progress after 3 attacks
 		# When the battle system is done, this will need to be changed
-		if 0 == total_enemies:
+		if 0 == enemy_unit_left:
 			move_to_next_stage()
 			temp_counter = 0
 		else:
@@ -113,30 +159,36 @@ func check_if_player_turn_complete():
 # Allow the enemy's unit to do a turn
 func run_enemy_turn():
 	print("Enemy turn!")
+	print($Friendlies.get_children())
+	print($Enemies.get_children())
 	var enemy_count = 0
 	for enemy in $Enemies.get_children():
 		# Only play animation for units that exist
 		var monstersArray = zone.Stage[current_stage-1].monsters
 		if enemy.is_unit and !monstersArray[enemy_count].is_dead:
-			print(enemy)
-			var unitToHurt = $Friendlies.get_random_target()
-			enemy.attack(unitToHurt.position)
-			$stats_checking.unit_taking_damage(monstersArray[enemy_count], units[unitToHurt.place_ID-1], true)
+			var unit_to_hurt = $Friendlies.get_random_target()
+			unit_to_hurt.time_being_targeted += 1
+			print(unit_to_hurt.time_being_targeted)
+			enemy.targeted_place_ID = unit_to_hurt.place_ID
+			enemy.attack(unit_to_hurt.position)
 			enemy.connect("AttackFinished", _enemy_attack_finished)
 		enemy_count = enemy_count + 1
 
 # When trigger, see if all alive enemies have made a move and will trigger the next friendly unit round or end the level
 func _enemy_attack_finished(unit_place: int):
 	# Disconnect the signal
-	get_node(str("./Enemies/Unit", unit_place)).disconnect("AttackFinished", _enemy_attack_finished)
+	var attacking_unit = get_node(str("./Enemies/Unit", unit_place))
+	attacking_unit.disconnect("AttackFinished", _enemy_attack_finished)
+	check_if_unit_is_dead(attacking_unit)
 	# Check if the turn is over
 	enemies_attacked = enemies_attacked + 1
+	print(total_enemies)
 	if (enemies_attacked == total_enemies):
 		print("Enemy turn over")
 		enemy_turn = false
 		player_turn = true
 		enemies_attacked = 0
-		total_allies = $stats_checking.are_units_dead(units, true)
+		total_allies = $stats_checking.are_all_units_dead(units, $Friendlies.get_children())
 		if 0 == total_allies:
 			print("Battle lost . . .")
 			_when_battle_end()
@@ -149,6 +201,8 @@ func load_next_stage(stage: int):
 	var counter = 0
 	total_enemies = 0
 	var enemy_units = $Enemies
+	player_turn = true
+	enemy_turn = false
 	enemy_units.clear_units()
 	resetUnitsStats()
 	for unit in zone.Stage[stage].monsters:
@@ -158,7 +212,7 @@ func load_next_stage(stage: int):
 				$BattleUI.set_selected_enemy_health(unit)
 			# Add enemy to field, start idle animation
 			var child_node = enemy_units.get_child(counter)
-			child_node.set_properties(unit.sprite_sheet, true,
+			child_node.set_properties(unit, true,
 				unit.char_equipment, unit.atk_equipment, unit.travel_equipment)
 			total_enemies = total_enemies + 1
 			
@@ -202,6 +256,7 @@ func _on_transition_show():
 # It would allow the unit to revive and so we should have every unit each round
 ### Maybe this is a useless function
 func resetUnitsStats():
+	units_attacked = 0
 	total_allies = 0
 	for unit in units:
 		if unit != null and !unit.is_dead:
@@ -211,20 +266,24 @@ func resetUnitsStats():
 # It will do some update like
 ### Hide the sprite of a unit
 ### Make the unit considered DEAD
-func _when_unit_has_died(place_ID: int, is_ally: bool = false):
-	print("signal the Unit %s has died" % place_ID)
+func when_unit_has_died(place_ID: int, is_ally: bool = false):
 	var team_unit = "Enemies" if !is_ally else "Friendlies"
+	print("signal the %s Unit %s has died" % [team_unit, place_ID])
 	var dead_unit = get_node(str("./", team_unit, "/Unit", place_ID))
+	dead_unit.is_dead = true
 	if is_ally:
 		var dead_unit_UI = get_node(str("./BattleUI/Unit", place_ID))
 		dead_unit_UI.unitHasDied()
+		units[place_ID - 1].is_dead = true
 	else:
-		var monsterUnits = zone.Stage[current_stage-1].monsters
-		var new_UI_unit_update = get_next_non_dead_unit(monsterUnits)
-		if null != new_UI_unit_update and monsterUnits[place_ID -1] == $BattleUI.selected_enemy:
+		var monsters_units = zone.Stage[current_stage-1].monsters
+		var new_UI_unit_update = get_next_non_dead_unit(monsters_units)
+		monsters_units[place_ID - 1].is_dead = true
+		if null != new_UI_unit_update and monsters_units[place_ID -1] == $BattleUI.selected_enemy:
 			$BattleUI.set_selected_enemy_health(new_UI_unit_update)
 		if place_ID == $Enemies.current_target:
 			$Enemies.current_target = -1
+		total_enemies -= 1
 	dead_unit.hide()
 	dead_unit.is_dead = true
 

--- a/Battle/battle.gd
+++ b/Battle/battle.gd
@@ -70,6 +70,8 @@ func battleUIUnitAttackConnect():
 	$BattleUI/Unit5.Attack.connect(_unit_attack)
 	$BattleUI/Unit6.Attack.connect(_unit_attack)
 
+# Called when the signal DamagingEnemy from field_unit is trigger
+# Will get all the data needed to do the damage calculation and update
 func _damaging_targeted_unit(damaging_unit_id: int, hurt_unit_id: int, quantity_of_damage: int):
 	var monsters_list = zone.Stage[current_stage - 1].monsters	
 	var damaging_field_unit
@@ -121,6 +123,7 @@ func _unit_attack_finished(unit_place: int):
 	check_if_unit_is_dead(friend_unit, true)
 	check_if_player_turn_complete()
 
+# Once the unit attack has ended, this method is called to see if the hurt unit is dead or not
 func check_if_unit_is_dead(unit, is_friendly_attacking: bool = false):
 	print("Is the unit dead ?")
 	var hurted_unit_place_ID = unit.targeted_place_ID

--- a/Battle/stats_checking.gd
+++ b/Battle/stats_checking.gd
@@ -1,31 +1,26 @@
 extends Node
 
-signal UnitHasDied(place_ID: int)
 signal FriendlyUnitHasTakenDamage(place_ID: int)
 
 # Make the defUnit lost HP
 # Right now, it only use the ATK stat of the atkUnit to reduce their HP
 # But in the future, we could use DEF and buff from unit
-func unit_taking_damage(atk_unit: Resource, def_unit: Resource, friend_is_hurt: bool = false):
-	def_unit.HP = def_unit.HP - atk_unit.ATK
+func unit_taking_damage(atk_unit_atk: int, def_unit: Resource, friend_is_hurt: bool = false):
+	def_unit.HP = def_unit.HP - atk_unit_atk
 	if friend_is_hurt:
 		emit_signal("FriendlyUnitHasTakenDamage", def_unit)
 
 # Function call at the end of each turn
 # It check if a every unit of a team (units) still have enought HP
 # If not, it emit the signal "unitHasDied" which is catch by battle.gd
-func are_units_dead(units: Array[Unit], isAllyUnits: bool = false):
+func are_all_units_dead(units: Array[Unit], field_units: Array[Node]):
 	var unitLeft = 0
-	var unitCount = 0
+	var unit_counter = 0
 	for unit in units:
-		unitCount += 1
-		if !isAllyUnits:
-			print(unit)
 		if null == unit:
+			unit_counter += 1
 			continue
-		if 0 >= unit.HP:
-			unit.is_dead = true
-			emit_signal("UnitHasDied", unitCount, isAllyUnits)
-		else:
+		if 0 < unit.HP or 0 < field_units[unit_counter].time_being_targeted:
 			unitLeft = unitLeft + 1
+		unit_counter += 1
 	return unitLeft

--- a/Menu/SubMenu/Unit/unit_menu.gd
+++ b/Menu/SubMenu/Unit/unit_menu.gd
@@ -16,6 +16,8 @@ func _on_button_pressed(button: int):
 	match button:
 		1:
 			get_parent().load_scene_home("res://Menu/SubMenu/Unit/Display/view_units.tscn")
+		2:
+			get_parent().load_scene_home("res://Menu/SubMenu/Unit/Squad/manage_squad.tscn")
 
 func _on_back_pressed():
 	get_parent().load_scene_home("res://Menu/SubMenu/Home/home.tscn")

--- a/Menu/SubMenu/Unit/unit_menu.gd
+++ b/Menu/SubMenu/Unit/unit_menu.gd
@@ -16,8 +16,6 @@ func _on_button_pressed(button: int):
 	match button:
 		1:
 			get_parent().load_scene_home("res://Menu/SubMenu/Unit/Display/view_units.tscn")
-		2:
-			get_parent().load_scene_home("res://Menu/SubMenu/Unit/Squad/manage_squad.tscn")
 
 func _on_back_pressed():
 	get_parent().load_scene_home("res://Menu/SubMenu/Home/home.tscn")

--- a/Testing/field_unit_test.gd
+++ b/Testing/field_unit_test.gd
@@ -6,7 +6,7 @@ extends Node2D
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	sprite.set_properties(unit.sprite_sheet, false, unit.char_equipment, unit.atk_equipment, unit.travel_equipment)
+	sprite.set_properties(unit, false, unit.char_equipment, unit.atk_equipment, unit.travel_equipment)
 
 
 func _on_button_pressed():

--- a/Units/Res/5/5.tres
+++ b/Units/Res/5/5.tres
@@ -138,6 +138,7 @@ arena_type = 3
 level = 1
 max_level = 12
 is_dead = false
+number_of_hit = Array[int]([50, 50])
 HP = 1000
 max_HP = 0
 ATK = 490

--- a/Units/unit_base.gd
+++ b/Units/unit_base.gd
@@ -29,6 +29,10 @@ var id: int = 0
 # Used to determine state in a battle
 @export var is_dead:bool = false
 
+@export_category("Hit")
+@export var number_of_hit:Array[int] = [100]
+
+@export_category("Fighting Stats")
 # Current health
 @export var HP: int = 0
 # Max health


### PR DESCRIPTION
Refers to Issue https://github.com/aMytho/brave-frontier-godot/issues/27

What this PR add to the game :
- When a unit is under attack, they have a "targeted increment" that goes up by 1 so the game know they are targeted by a unit
- When a unit end an attack on a targeted unit, the "targeted increment" goes down by 1
- - When it goes back to 0, the game would see if the unit is dead. And if yes, it does everything it were doing actually
- - And only if the unit don't have a "targeted increment" > 0 isconsidered dead when HP <= 0
- When a unit have a multiple hit attack, the attack event will be trigger one by one by the field_unit `_on_move_finished`
- - @aMytho there is a casuality (not a problem) implemented this way : all the attacks are send at the same time. I don't know how the attack animation would work, if certain frame of a unit are marked as "deal damage". I might let you see this part.
- - You can see at the unit_base.gd, we have now an array "number_of_hit" (which should change their name to "percent of damage by hit" or something like that). You just have to specify the percent you want in there for each hit of an attack and BOOM you will deal the damage separatly (as said before, damage are dealth separatly, but the animation/attack is too fast to see the change in the UI)

What need to be fix :
- At the moment, the enemy lifebar UI. When a unit dies during the round, the enemy UI healthbar still show the dead unit if focused.

A preview of the work, as always : https://drive.google.com/file/d/1IKBf2as-rfWFaGO1jgj3MfcZjRE7hhiP/view?usp=sharing (i didn't show the last stage, but the work is the same)

I will take care of the healthbar tomorrow and add/update the comment in the code. So @aMytho , if you have any review about the code, go for it !

Have a good Day/Night !